### PR TITLE
HW9: Saravayskiy Mike

### DIFF
--- a/src/main/java/impl/network/FollowersStatsFactory.java
+++ b/src/main/java/impl/network/FollowersStatsFactory.java
@@ -5,6 +5,6 @@ import api.network.SocialNetwork;
 
 public class FollowersStatsFactory {
     public static FollowersStats getInstance(SocialNetwork network) {
-        return null;
+        return new FollowersStatsImpl(network);
     }
 }

--- a/src/main/java/impl/network/FollowersStatsImpl.java
+++ b/src/main/java/impl/network/FollowersStatsImpl.java
@@ -4,15 +4,11 @@ import api.network.FollowersStats;
 import api.network.SocialNetwork;
 import api.network.UserInfo;
 
-import java.util.*;
 import java.util.concurrent.*;
 import java.util.function.Predicate;
 
 public class FollowersStatsImpl implements FollowersStats {
     private SocialNetwork network;
-
-    private Map<Integer, UserInfo> userInfoCache = new ConcurrentHashMap<>();
-    private Map<Integer, Collection<Integer>> followersCache = new ConcurrentHashMap<>();
 
     public FollowersStatsImpl(SocialNetwork network) {
         this.network = network;
@@ -20,67 +16,33 @@ public class FollowersStatsImpl implements FollowersStats {
 
     @Override
     public Future<Integer> followersCountBy(int id, int depth, Predicate<UserInfo> predicate) {
-        return CompletableFuture.completedFuture(
-                doCountFollowersBy(id, depth, predicate,
-                        new ConcurrentHashMap<>() {{
-                            put(id, id);
-                        }}
-                ));
+        return doCountFollowersBy(id, depth, predicate,
+                new ConcurrentHashMap<>() {{
+                    put(id, id);
+                }}
+        );
     }
 
-    private Integer doCountFollowersBy(int id, int depth, Predicate<UserInfo> predicate, ConcurrentHashMap<Integer, Integer> visited) {
-        try {
-            var userInfo = getUserInfo(id);
-
-            var thisUserValue = predicate.test(userInfo) ? 1 : 0;
-
-            if (depth == 0) {
-                return thisUserValue;
-            }
-
-            var followersFutures = new ArrayList<Future<Integer>>();
-            for (var followerId : getUserFollowers(id)) {
-
-                if (visited.putIfAbsent(followerId, followerId) != null) {
-                    continue;
-                }
-                followersFutures.add(
-                        CompletableFuture.supplyAsync(() -> doCountFollowersBy(followerId, depth - 1, predicate, visited))
+    private CompletableFuture<Integer> doCountFollowersBy(int id, int depth, Predicate<UserInfo> predicate, ConcurrentHashMap<Integer, Integer> visited) {
+        var userCountFuture = network.getUserInfo(id)
+                .thenApply(
+                        (userInfo) -> predicate.test(userInfo) ? 1 : 0
                 );
-            }
+        if (depth == 0) return userCountFuture;
 
-            for (var future : followersFutures) {
-                thisUserValue += future.get();
-            }
-
-            return thisUserValue;
-        } catch (InterruptedException | ExecutionException e) {
-            System.err.println(String.format("Something went wrong: %s", e.getMessage()));
-            return null;
-        }
+        return network.getFollowers(id)
+                .thenCompose(
+                        (followers) ->
+                                followers.stream()
+                                        .map(
+                                                follower -> {
+                                                    if (visited.putIfAbsent(follower, follower) != null) {
+                                                        return CompletableFuture.completedFuture(0);
+                                                    }
+                                                    return doCountFollowersBy(follower, depth - 1, predicate, visited);
+                                                })
+                                        .reduce((l, r) -> l.thenCombine(r, Integer::sum))
+                                        .orElse(CompletableFuture.completedFuture(0)))
+                .thenCombine(userCountFuture, Integer::sum);
     }
-
-    private UserInfo getUserInfo(int id) {
-        return userInfoCache.computeIfAbsent(id, (k) -> {
-            try {
-                return network.getUserInfo(id).get();
-            } catch (InterruptedException | ExecutionException e) {
-                System.err.println(String.format("Something went wrong: %s", e.getMessage()));
-                return null; // this way we will not add anything to the map
-            }
-        });
-    }
-
-    private Collection<Integer> getUserFollowers(int id) {
-        return followersCache.computeIfAbsent(id,
-                (k) -> {
-                    try {
-                        return network.getFollowers(id).get();
-                    } catch (InterruptedException | ExecutionException e) {
-                        System.err.println(String.format("Something went wrong: %s", e.getMessage()));
-                        return null; // this way we will not add anything to the map
-                    }
-                });
-    }
-
 }

--- a/src/main/java/impl/network/FollowersStatsImpl.java
+++ b/src/main/java/impl/network/FollowersStatsImpl.java
@@ -1,0 +1,95 @@
+package impl.network;
+
+import api.network.FollowersStats;
+import api.network.SocialNetwork;
+import api.network.UserInfo;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.function.Predicate;
+
+public class FollowersStatsImpl implements FollowersStats {
+    private SocialNetwork network;
+
+    private Map<Integer, UserInfo> userInfoCache = new ConcurrentHashMap<>();
+    private Map<Integer, Collection<Integer>> followersCache = new ConcurrentHashMap<>();
+    private Map<Integer, Integer> userIdLocks = new ConcurrentHashMap<>();
+
+    public FollowersStatsImpl(SocialNetwork network) {
+        this.network = network;
+    }
+
+    @Override
+    public Future<Integer> followersCountBy(int id, int depth, Predicate<UserInfo> predicate) {
+//        if (depth == 0) return CompletableFuture.completedFuture(0); //Wow, this is ugly
+        try {
+            return doCountFollowersBY(id, depth, predicate, new ArrayList<>());
+        } catch (InterruptedException | ExecutionException e) {
+            System.err.println(String.format("Something went wrong during followers count (depth %d): %s", depth, e.getMessage()));
+            return null;
+        }
+    }
+
+    private Future<Integer> doCountFollowersBY(int id, int depth, Predicate<UserInfo> predicate, List<Integer> visited)
+            throws ExecutionException, InterruptedException {
+        var thisUserValue = 0;
+        synchronized (getCacheSyncObject(id)) {
+            if (!visited.contains(id)) { // Or we can do this in the loop below, dunno what is more performant, dunno what is safer
+                var userInfo = getUserInfo(id);
+                thisUserValue = predicate.test(userInfo) ? 1 : 0;
+                visited.add(id);
+            }
+        }
+        if (depth == 0) {
+            return CompletableFuture.completedFuture(thisUserValue);
+        }
+
+        var followersFutures = new ArrayList<Future<Integer>>();
+        for (var followerID : getUserFollowers(id)) {
+            // We can double check if we already visited follower here
+            followersFutures.add(doCountFollowersBY(followerID, depth - 1, predicate, visited));
+        }
+
+        for (var future: followersFutures){
+            thisUserValue += future.get();
+        }
+
+
+        return CompletableFuture.completedFuture(thisUserValue);
+    }
+
+    private Object getCacheSyncObject(final Integer id) {
+//        Here we store the very first autoboxed Integer as an object to sync around
+        userIdLocks.putIfAbsent(id, id);
+        return userIdLocks.get(id);
+    }
+
+    private UserInfo getUserInfo(int id) throws ExecutionException, InterruptedException {
+        // Ok, here for each id we try to get some object to synchronize around, we store those in separate concurrentMap
+        // We use (autoboxed)Integer as map key, but since checking for already being there is based on equals()
+        //    we will not create separate locks for different boxed Integer instances.
+        synchronized (getCacheSyncObject(id)) {
+            if (!userInfoCache.containsKey(id)) {
+                userInfoCache.put(id, network.getUserInfo(id).get());
+            }
+        }
+        return userInfoCache.get(id);
+    }
+
+    private Collection<Integer> getUserFollowers(int id) throws ExecutionException, InterruptedException {
+        synchronized (getCacheSyncObject(id)) {
+            if (!followersCache.containsKey(id)) {
+                followersCache.put(id, network.getFollowers(id).get());
+            }
+        }
+        return followersCache.get(id);
+    }
+
+}

--- a/src/main/java/impl/network/FollowersStatsImpl.java
+++ b/src/main/java/impl/network/FollowersStatsImpl.java
@@ -3,12 +3,8 @@ package impl.network;
 import api.network.FollowersStats;
 import api.network.SocialNetwork;
 import api.network.UserInfo;
-import org.jetbrains.annotations.Nullable;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
@@ -28,53 +24,84 @@ public class FollowersStatsImpl implements FollowersStats {
 
     @Override
     public Future<Integer> followersCountBy(int id, int depth, Predicate<UserInfo> predicate) {
-//        if (depth == 0) return CompletableFuture.completedFuture(0); //Wow, this is ugly
         try {
-            return doCountFollowersBY(id, depth, predicate, new ArrayList<>());
+            return doCountFollowersBy(id, depth, predicate,
+                    new ConcurrentHashMap<>() {{
+                        put(id, id);
+                    }}
+//                    new HashSet<>() {{  // WHY DOES Set.of(id) RETURN IMMUTABLE SET?!
+//                        add(id);        // This ends up being ugly... Stream.of().collectToSet is also ugly
+//                    }}
+            );
         } catch (InterruptedException | ExecutionException e) {
             System.err.println(String.format("Something went wrong during followers count (depth %d): %s", depth, e.getMessage()));
-            return null;
+            return CompletableFuture.completedFuture(0); //Or null, dunno, not specified =)
         }
     }
 
-    private Future<Integer> doCountFollowersBY(int id, int depth, Predicate<UserInfo> predicate, List<Integer> visited)
+    /**
+     * Recursively counts followers in a network that satisfy given predicate
+     *
+     * @param id        id of a user to start count followers
+     * @param depth     max depth of recursive travers
+     * @param predicate predicate to check
+     * @param visited   accumulator of already visited nodes so that we don't count the same user twice
+     */
+    private Future<Integer> doCountFollowersBy(int id, int depth, Predicate<UserInfo> predicate, ConcurrentHashMap<Integer, Integer> visited)//Set<Integer> visited)
             throws ExecutionException, InterruptedException {
-        var thisUserValue = 0;
-        synchronized (getCacheSyncObject(id)) {
-            if (!visited.contains(id)) { // Or we can do this in the loop below, dunno what is more performant, dunno what is safer
-                var userInfo = getUserInfo(id);
-                thisUserValue = predicate.test(userInfo) ? 1 : 0;
-                visited.add(id);
-            }
-        }
+
+        var userInfo = getUserInfo(id);
+
+        var thisUserValue = predicate.test(userInfo) ? 1 : 0;
+
         if (depth == 0) {
-            return CompletableFuture.completedFuture(thisUserValue);
+            return CompletableFuture.completedFuture(thisUserValue); //Wow, this is ugly
         }
 
         var followersFutures = new ArrayList<Future<Integer>>();
-        for (var followerID : getUserFollowers(id)) {
-            // We can double check if we already visited follower here
-            followersFutures.add(doCountFollowersBY(followerID, depth - 1, predicate, visited));
+        for (var followerId : getUserFollowers(id)) {
+
+//            This is a leftover from when visited was a Set
+//            synchronized (getCacheSyncObject(id)) {
+//                if (!visited.contains(followerId)) {
+//                    visited.add(followerId);
+//                } else {
+//                    continue;
+//                }
+//            }
+            // this is thread-safe without additional synchronization, right? right?
+            if (visited.putIfAbsent(followerId, followerId) != null) { //very readable tho...
+                continue;
+            }
+            followersFutures.add(doCountFollowersBy(followerId, depth - 1, predicate, visited));
         }
 
-        for (var future: followersFutures){
+        for (var future : followersFutures) {
             thisUserValue += future.get();
         }
-
 
         return CompletableFuture.completedFuture(thisUserValue);
     }
 
+    /**
+     * Returns object that can be used as synchronize object around cache access
+     * Ok, here for each id we try to get some object to synchronize around, we store those in separate concurrentMap
+     * We use (autoboxed)Integer as map key, but since checking for already being there is based on equals()
+     * we will not create separate locks for different boxed Integer instances.
+     * Here we store the very first autoboxed Integer as an object to sync around
+     * This is needed so that putIfAbsent is atomic and we don't create new objects per call:
+     * userIdLocks.putIfAbsent(id, new Object()) <- creates new Object before call even if we don't need it
+     * if(userIdLocks.containsKey(id) userIdLocks.put(id, new Object) <- not atomic
+     *
+     * @param id int id of synch object.
+     * @return Object (Integer really) unique object to synchronize around to access caches.
+     */
     private Object getCacheSyncObject(final Integer id) {
-//        Here we store the very first autoboxed Integer as an object to sync around
         userIdLocks.putIfAbsent(id, id);
         return userIdLocks.get(id);
     }
 
     private UserInfo getUserInfo(int id) throws ExecutionException, InterruptedException {
-        // Ok, here for each id we try to get some object to synchronize around, we store those in separate concurrentMap
-        // We use (autoboxed)Integer as map key, but since checking for already being there is based on equals()
-        //    we will not create separate locks for different boxed Integer instances.
         synchronized (getCacheSyncObject(id)) {
             if (!userInfoCache.containsKey(id)) {
                 userInfoCache.put(id, network.getUserInfo(id).get());

--- a/src/main/java/impl/network/FollowersStatsImpl.java
+++ b/src/main/java/impl/network/FollowersStatsImpl.java
@@ -5,10 +5,7 @@ import api.network.SocialNetwork;
 import api.network.UserInfo;
 
 import java.util.*;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
+import java.util.concurrent.*;
 import java.util.function.Predicate;
 
 public class FollowersStatsImpl implements FollowersStats {
@@ -16,7 +13,6 @@ public class FollowersStatsImpl implements FollowersStats {
 
     private Map<Integer, UserInfo> userInfoCache = new ConcurrentHashMap<>();
     private Map<Integer, Collection<Integer>> followersCache = new ConcurrentHashMap<>();
-    private Map<Integer, Integer> userIdLocks = new ConcurrentHashMap<>();
 
     public FollowersStatsImpl(SocialNetwork network) {
         this.network = network;
@@ -24,99 +20,67 @@ public class FollowersStatsImpl implements FollowersStats {
 
     @Override
     public Future<Integer> followersCountBy(int id, int depth, Predicate<UserInfo> predicate) {
+        return CompletableFuture.completedFuture(
+                doCountFollowersBy(id, depth, predicate,
+                        new ConcurrentHashMap<>() {{
+                            put(id, id);
+                        }}
+                ));
+    }
+
+    private Integer doCountFollowersBy(int id, int depth, Predicate<UserInfo> predicate, ConcurrentHashMap<Integer, Integer> visited) {
         try {
-            return doCountFollowersBy(id, depth, predicate,
-                    new ConcurrentHashMap<>() {{
-                        put(id, id);
-                    }}
-//                    new HashSet<>() {{  // WHY DOES Set.of(id) RETURN IMMUTABLE SET?!
-//                        add(id);        // This ends up being ugly... Stream.of().collectToSet is also ugly
-//                    }}
-            );
+            var userInfo = getUserInfo(id);
+
+            var thisUserValue = predicate.test(userInfo) ? 1 : 0;
+
+            if (depth == 0) {
+                return thisUserValue;
+            }
+
+            var followersFutures = new ArrayList<Future<Integer>>();
+            for (var followerId : getUserFollowers(id)) {
+
+                if (visited.putIfAbsent(followerId, followerId) != null) {
+                    continue;
+                }
+                followersFutures.add(
+                        CompletableFuture.supplyAsync(() -> doCountFollowersBy(followerId, depth - 1, predicate, visited))
+                );
+            }
+
+            for (var future : followersFutures) {
+                thisUserValue += future.get();
+            }
+
+            return thisUserValue;
         } catch (InterruptedException | ExecutionException e) {
-            System.err.println(String.format("Something went wrong during followers count (depth %d): %s", depth, e.getMessage()));
-            return CompletableFuture.completedFuture(0); //Or null, dunno, not specified =)
+            System.err.println(String.format("Something went wrong: %s", e.getMessage()));
+            return null;
         }
     }
 
-    /**
-     * Recursively counts followers in a network that satisfy given predicate
-     *
-     * @param id        id of a user to start count followers
-     * @param depth     max depth of recursive travers
-     * @param predicate predicate to check
-     * @param visited   accumulator of already visited nodes so that we don't count the same user twice
-     */
-    private Future<Integer> doCountFollowersBy(int id, int depth, Predicate<UserInfo> predicate, ConcurrentHashMap<Integer, Integer> visited)//Set<Integer> visited)
-            throws ExecutionException, InterruptedException {
-
-        var userInfo = getUserInfo(id);
-
-        var thisUserValue = predicate.test(userInfo) ? 1 : 0;
-
-        if (depth == 0) {
-            return CompletableFuture.completedFuture(thisUserValue); //Wow, this is ugly
-        }
-
-        var followersFutures = new ArrayList<Future<Integer>>();
-        for (var followerId : getUserFollowers(id)) {
-
-//            This is a leftover from when visited was a Set
-//            synchronized (getCacheSyncObject(id)) {
-//                if (!visited.contains(followerId)) {
-//                    visited.add(followerId);
-//                } else {
-//                    continue;
-//                }
-//            }
-            // this is thread-safe without additional synchronization, right? right?
-            if (visited.putIfAbsent(followerId, followerId) != null) { //very readable tho...
-                continue;
+    private UserInfo getUserInfo(int id) {
+        return userInfoCache.computeIfAbsent(id, (k) -> {
+            try {
+                return network.getUserInfo(id).get();
+            } catch (InterruptedException | ExecutionException e) {
+                System.err.println(String.format("Something went wrong: %s", e.getMessage()));
+                return null; // this way we will not add anything to the map
             }
-            followersFutures.add(doCountFollowersBy(followerId, depth - 1, predicate, visited));
-        }
-
-        for (var future : followersFutures) {
-            thisUserValue += future.get();
-        }
-
-        return CompletableFuture.completedFuture(thisUserValue);
+        });
     }
 
-    /**
-     * Returns object that can be used as synchronize object around cache access
-     * Ok, here for each id we try to get some object to synchronize around, we store those in separate concurrentMap
-     * We use (autoboxed)Integer as map key, but since checking for already being there is based on equals()
-     * we will not create separate locks for different boxed Integer instances.
-     * Here we store the very first autoboxed Integer as an object to sync around
-     * This is needed so that putIfAbsent is atomic and we don't create new objects per call:
-     * userIdLocks.putIfAbsent(id, new Object()) <- creates new Object before call even if we don't need it
-     * if(userIdLocks.containsKey(id) userIdLocks.put(id, new Object) <- not atomic
-     *
-     * @param id int id of synch object.
-     * @return Object (Integer really) unique object to synchronize around to access caches.
-     */
-    private Object getCacheSyncObject(final Integer id) {
-        userIdLocks.putIfAbsent(id, id);
-        return userIdLocks.get(id);
-    }
-
-    private UserInfo getUserInfo(int id) throws ExecutionException, InterruptedException {
-        synchronized (getCacheSyncObject(id)) {
-            if (!userInfoCache.containsKey(id)) {
-                userInfoCache.put(id, network.getUserInfo(id).get());
-            }
-        }
-        return userInfoCache.get(id);
-    }
-
-    private Collection<Integer> getUserFollowers(int id) throws ExecutionException, InterruptedException {
-        synchronized (getCacheSyncObject(id)) {
-            if (!followersCache.containsKey(id)) {
-                followersCache.put(id, network.getFollowers(id).get());
-            }
-        }
-        return followersCache.get(id);
+    private Collection<Integer> getUserFollowers(int id) {
+        return followersCache.computeIfAbsent(id,
+                (k) -> {
+                    try {
+                        return network.getFollowers(id).get();
+                    } catch (InterruptedException | ExecutionException e) {
+                        System.err.println(String.format("Something went wrong: %s", e.getMessage()));
+                        return null; // this way we will not add anything to the map
+                    }
+                });
     }
 
 }


### PR DESCRIPTION
Implemented the Stats thingy in the following way:

We call private method with the accumulator that tracks already visited (counted) users and add the root user there right away.
Once we see new id in followers list - we add to the accumulator and call the same method recursively.
That allows to visit each user only once and safely check that user was already visited only once
To access network only once per userstats/followers list - we have ConcurrentHashMaps as caches.

There is no waiting, no additional overhead for parallelization, no nothing ugly (except some java syntax)

BUT I STILL COULDN'T BEAT 2 threads vs 1 thread test!
![image](https://user-images.githubusercontent.com/2794213/82367253-2e040a80-9a1c-11ea-9123-1d0dca29086b.png)
`5934963800 > 4660506200` tho
